### PR TITLE
Fix open handle in install-utils

### DIFF
--- a/lib/install-utils.js
+++ b/lib/install-utils.js
@@ -5,6 +5,7 @@ const mkdirp = require('mkdirp');
 const path = require('path');
 const yauzl = require('yauzl');
 const fs = require('fs');
+const zlib = require('zlib');
 const got = require('got');
 const merge = require('lodash.merge');
 const debug = require('debug')('selenium-standalone:install');
@@ -160,7 +161,7 @@ async function uncompressDownloadedFile(zipFilePath) {
 
 async function uncompressGzippedFile(from, gzipFilePath) {
   return new Promise((resolve, reject) => {
-    const gunzip = require('zlib').createGunzip();
+    const gunzip = zlib.createGunzip();
     const extractPath = path.join(path.dirname(gzipFilePath), path.basename(gzipFilePath, '.gz'));
     const writeStream = fs
       .createWriteStream(extractPath)

--- a/lib/install-utils.js
+++ b/lib/install-utils.js
@@ -4,7 +4,6 @@ const crypto = require('crypto');
 const mkdirp = require('mkdirp');
 const path = require('path');
 const yauzl = require('yauzl');
-const gunzip = require('zlib').createGunzip();
 const fs = require('fs');
 const got = require('got');
 const merge = require('lodash.merge');
@@ -161,6 +160,7 @@ async function uncompressDownloadedFile(zipFilePath) {
 
 async function uncompressGzippedFile(from, gzipFilePath) {
   return new Promise((resolve, reject) => {
+    const gunzip = require('zlib').createGunzip();
     const extractPath = path.join(path.dirname(gzipFilePath), path.basename(gzipFilePath, '.gz'));
     const writeStream = fs
       .createWriteStream(extractPath)


### PR DESCRIPTION
I was using selenium with jest and I got complaints about an open handle in install-utils. My hypothesis is that the test setup that I am using does not use `uncompressGzippedFile` function and the gunzip stream is never used/closed. Moving the creation of the gunzip stream inside the method fixed my problem. 