### PR TITLE
Add message for edgedriver download failures

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -301,7 +301,21 @@ async function install(_opts) {
         .once('end', () => {
           downloadStreams.delete(downloadStream);
         })
-        .once('error', (err) => reject(logError('getDownloadStream', err, 'Could not download ' + downloadUrl)));
+        .once('error', (err) => {
+          if (err.code === 'ERR_NON_2XX_3XX_RESPONSE' && downloadUrl.includes('edge')) {
+            reject(
+              logError(
+                'getDownloadStream',
+                err,
+                'It may be due to the specified edge driver version ' +
+                  downloadUrl.split('/')[3] +
+                  ' is unavailable for current platform. Try downloading a different version of edge driver '
+              )
+            );
+          } else {
+            reject(logError('getDownloadStream', err, 'Could not download ' + downloadUrl));
+          }
+        });
     });
   }
 }

--- a/lib/log-error.js
+++ b/lib/log-error.js
@@ -1,5 +1,5 @@
 const logError = (fnName, error, message = '') => {
-  console.error(`Error in "${fnName}". ${message}\nSee more details below:`);
+  console.error(`\nError in "${fnName}". ${message}\nSee more details below:`);
   if (error) {
     if (error.response) {
       console.log(error.response.statusCode, error.response.url);


### PR DESCRIPTION
As edge driver is unavailable for a few versions on fewer platforms, Webdriverio fails to start the server with 404 messages.

This PR is to print a precise message in case if this happens.
**Note**: This issue only occurs for chromiumedge webdriver downloads.

HI @christian-bromann,

May not be perfect, but let me know if this works!

![Screenshot 2021-11-25 at 8 29 34 PM](https://user-images.githubusercontent.com/12621691/143463958-6cf2b28c-2cfe-449e-a30a-2276e56b6c1a.png)
