### PR TITLE
Fix selenium-webdriver patch versions dowload for v4

### DIFF
--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -44,7 +44,9 @@ async function computeDownloadUrls(opts) {
       util.format(
         isSelenium4(opts.seleniumVersion) ? urls.seleniumV4 : urls.selenium,
         opts.seleniumBaseURL,
-        `selenium-${opts.seleniumVersion}`,
+        `selenium-${
+          isSelenium4(opts.seleniumVersion) ? getVersionWithZeroedPatchPart(opts.seleniumVersion) : opts.seleniumVersion
+        }`,
         opts.seleniumVersion
       ),
   };
@@ -252,4 +254,14 @@ async function getLatestGeckodriver(opts, browserDriver, url) {
     opts.drivers[browserDriver].version = response.body.name;
     return true;
   }
+}
+
+function getVersionWithZeroedPatchPart(fullVersion) {
+  if (!/^\d+\.\d+\.\d+$/i.test(fullVersion)) {
+    // If version longer than just 3 numbers, like '4.0.0-beta-1', do nothing
+    return fullVersion;
+  }
+  // else make version patch part zero: '4.1.1' => '4.1.0'
+  const [major, minor] = fullVersion.split('.');
+  return `${major}.${minor}.0`;
 }

--- a/test/compute-download-urls-test.js
+++ b/test/compute-download-urls-test.js
@@ -62,6 +62,36 @@ describe('compute-download-urls', () => {
       );
     });
 
+    it('version 4 basic', async () => {
+      const actual = await computeDownloadUrls({
+        seleniumVersion: '4.1.0',
+        seleniumBaseURL: 'https://localhost',
+        drivers: {},
+      });
+
+      assert.strictEqual(actual.selenium, 'https://localhost/selenium-4.1.0/selenium-server-4.1.0.jar');
+    });
+
+    it('version 4 with patch', async () => {
+      const actual = await computeDownloadUrls({
+        seleniumVersion: '4.1.1',
+        seleniumBaseURL: 'https://localhost',
+        drivers: {},
+      });
+
+      assert.strictEqual(actual.selenium, 'https://localhost/selenium-4.1.0/selenium-server-4.1.1.jar');
+    });
+
+    it('version 4 with beta string', async () => {
+      const actual = await computeDownloadUrls({
+        seleniumVersion: '4.0.0-beta-3',
+        seleniumBaseURL: 'https://localhost',
+        drivers: {},
+      });
+
+      assert.strictEqual(actual.selenium, 'https://localhost/selenium-4.0.0-beta-3/selenium-server-4.0.0-beta-3.jar');
+    });
+
     it('fullURL', async () => {
       const actual = await computeDownloadUrls({
         seleniumVersion: '4.0.0-alpha-7',


### PR DESCRIPTION
Added patch version zeroing for selenium-server v4 downloading.
Added a few tests for v4 url generations.

Fixes #604 