### PR TITLE
Adjustments to `start` Options

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -123,7 +123,7 @@ async function start(_opts) {
     throw new Error(`Port ${seleniumStatusUrl.port} is already in use.`);
   }
 
-  if(!opts.spawnOptions.stdio) {
+  if (!opts.spawnOptions.stdio) {
     opts.spawnOptions.stdio = 'ignore'
   }
 

--- a/lib/start.js
+++ b/lib/start.js
@@ -27,7 +27,7 @@ async function start(_opts) {
     opts.seleniumArgs = [];
   }
 
-  if( !opts.spawnOptions ) {
+  if(!opts.spawnOptions) {
     opts.spawnOptions = {}
   }
 

--- a/lib/start.js
+++ b/lib/start.js
@@ -27,6 +27,10 @@ async function start(_opts) {
     opts.seleniumArgs = [];
   }
 
+  if( !opts.spawnOptions ) {
+    opts.spawnOptions = {}
+  }
+
   if (!opts.version) {
     opts.version = defaultConfig.version;
   }
@@ -38,6 +42,8 @@ async function start(_opts) {
     !hasParam(opts.seleniumArgs, 'standalone') &&
     !hasParam(opts.seleniumArgs, 'distributor')
   ) {
+    opts.seleniumArgs.unshift('false');
+    opts.seleniumArgs.unshift('--detect-drivers');
     opts.seleniumArgs.unshift('standalone');
   }
 
@@ -115,6 +121,10 @@ async function start(_opts) {
   const seleniumStatusUrl = statusUrl.getSeleniumStatusUrl(args, opts);
   if (await isPortReachable(seleniumStatusUrl.port, { timeout: 100 })) {
     throw new Error(`Port ${seleniumStatusUrl.port} is already in use.`);
+  }
+
+  if( !opts.spawnOptions.stdio ) {
+    opts.spawnOptions.stdio = 'ignore'
   }
 
   debug('Spawning Selenium Server process', opts.javaPath, args);

--- a/lib/start.js
+++ b/lib/start.js
@@ -27,7 +27,7 @@ async function start(_opts) {
     opts.seleniumArgs = [];
   }
 
-  if(!opts.spawnOptions) {
+  if (!opts.spawnOptions) {
     opts.spawnOptions = {}
   }
 

--- a/lib/start.js
+++ b/lib/start.js
@@ -123,7 +123,7 @@ async function start(_opts) {
     throw new Error(`Port ${seleniumStatusUrl.port} is already in use.`);
   }
 
-  if( !opts.spawnOptions.stdio ) {
+  if(!opts.spawnOptions.stdio) {
     opts.spawnOptions.stdio = 'ignore'
   }
 

--- a/lib/start.js
+++ b/lib/start.js
@@ -28,7 +28,7 @@ async function start(_opts) {
   }
 
   if (!opts.spawnOptions) {
-    opts.spawnOptions = {}
+    opts.spawnOptions = {};
   }
 
   if (!opts.version) {

--- a/lib/start.js
+++ b/lib/start.js
@@ -124,7 +124,7 @@ async function start(_opts) {
   }
 
   if (!opts.spawnOptions.stdio) {
-    opts.spawnOptions.stdio = 'ignore'
+    opts.spawnOptions.stdio = 'ignore';
   }
 
   debug('Spawning Selenium Server process', opts.javaPath, args);


### PR DESCRIPTION
Could not get the test suite to pass. Ran into two issues due to options (or lack of options) being passed to the `start` function. Rather than adjust the test suite to pass the necessary option I thought it would be better to adjust the API to have defaults so the options are not necessary.

Spawn Options Stdio
================

This defaults to [`pipe`](https://nodejs.org/api/child_process.html#optionsstdio). With this default the behavior I was getting is that the `checkStarted` was always failing. This was obviously not an issue at some point. I am guessing that the selenium jar file changed it's behavior so that it didn't fully boot up until some stdio activity occurred and since this library is not interacting with that pipe it remained not booted.

I noticed the `bin/selenium-standalone` script did not have a problem booting the server. After a bit of debugging determined it is because [it sets the spawnOptions.stdio to `inherit`](https://github.com/webdriverio/selenium-standalone/blob/main/bin/selenium-standalone#L125-L127). This allows that sub-process to not be blocked by stdio.

I considered also defaulting spawnOptions.stdio to 'inhert' with the API but I'm not sure writing on top of the parent's STDIO is the right default behavior. It would seem being quite and squashing stdio (sending to /dev/null) is a better default so I set it to
`ignore`. Obviously if this is not the right behavior for a specific application they can always override.

Add `--detect-drivers false` Option
==========================

Once the above fix to the boot process was made I was still getting a problem with one test, "should start with the given drivers", where no driver are being specified.

When this is run the selenium-standalone jar was giving me the following error:

```
10:56:47.730 INFO [LoggingOptions.configureLogEncoding] - Using the system default encoding
10:56:47.733 INFO [OpenTelemetryTracer.createTracer] - Using OpenTelemetry for tracing
10:56:48.170 INFO [NodeOptions.getSessionFactories] - Detected 8 available processors
10:56:48.181 INFO [NodeOptions.discoverDrivers] - Discovered 0 driver(s)
10:56:48.187 WARN [NodeOptions.addDetectedDrivers] - No drivers have been configured or have been found on PATH
java.lang.reflect.InvocationTargetException
 at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
 at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 at java.base/java.lang.reflect.Method.invoke(Method.java:566)
 at org.openqa.selenium.grid.Bootstrap.runMain(Bootstrap.java:77)
 at org.openqa.selenium.grid.Bootstrap.main(Bootstrap.java:70)
Caused by: org.openqa.selenium.grid.config.ConfigException: java.lang.reflect.InvocationTargetException
 at org.openqa.selenium.grid.config.MemoizedConfig.getClass(MemoizedConfig.java:115)
 at org.openqa.selenium.grid.node.config.NodeOptions.getNode(NodeOptions.java:131)
 at org.openqa.selenium.grid.commands.Standalone.createHandlers(Standalone.java:203)
 at org.openqa.selenium.grid.TemplateGridServerCommand.asServer(TemplateGridServerCommand.java:41)
 at org.openqa.selenium.grid.commands.Standalone.execute(Standalone.java:214)
 at org.openqa.selenium.grid.TemplateGridCommand.lambda$configure$4(TemplateGridCommand.java:129)
 at org.openqa.selenium.grid.Main.launch(Main.java:83)
 at org.openqa.selenium.grid.Main.go(Main.java:57)
 at org.openqa.selenium.grid.Main.main(Main.java:42)
 ... 6 more
Caused by: java.lang.reflect.InvocationTargetException
 at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
 at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 at java.base/java.lang.reflect.Method.invoke(Method.java:566)
 at org.openqa.selenium.grid.config.ClassCreation.callCreateMethod(ClassCreation.java:50)
 at org.openqa.selenium.grid.config.MemoizedConfig.lambda$getClass$4(MemoizedConfig.java:100)
 at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1737)
 at org.openqa.selenium.grid.config.MemoizedConfig.getClass(MemoizedConfig.java:95)
 ... 14 more
Caused by: org.openqa.selenium.grid.config.ConfigException: No drivers have been configured or have been found on PATH
 at org.openqa.selenium.grid.node.config.NodeOptions.addDetectedDrivers(NodeOptions.java:403)
 at org.openqa.selenium.grid.node.config.NodeOptions.getSessionFactories(NodeOptions.java:192)
 at org.openqa.selenium.grid.node.local.LocalNodeFactory.create(LocalNodeFactory.java:76)
 ... 22 more
```

It seems if no driver is specified then it will try searching for drivers on the system. My guess is if there are some in `PATH` then it will boot fine. But on my system there are none in `PATH` so it fails with this error.

Since this library is specifying explicit paths to all drivers it seems the detection is not necessary. By disabling it we prevent the error from occurring on systems like mine.