### PR TITLE
Fix Selenium URLs prior to v4

### DIFF
--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -46,7 +46,7 @@ async function computeDownloadUrls(opts) {
         opts.seleniumBaseURL,
         isSelenium4(opts.seleniumVersion)
           ? `selenium-${getVersionWithZeroedPatchPart(opts.seleniumVersion)}`
-          : opts.seleniumVersion.replace(/(\d+\.\d+)\.\d+/, '$1'),
+          : `selenium-${opts.seleniumVersion}`,
         opts.seleniumVersion
       ),
   };

--- a/test/compute-download-urls-test.js
+++ b/test/compute-download-urls-test.js
@@ -1,4 +1,6 @@
 const assert = require('assert');
+const got = require('got');
+const defaults = require('../lib/default-config.js')();
 
 let computeDownloadUrls;
 
@@ -56,7 +58,10 @@ describe('compute-download-urls', () => {
         drivers: {},
       });
 
-      assert.strictEqual(actual.selenium, 'https://localhost/selenium-3.0.0-beta2/selenium-server-standalone-3.0.0-beta2.jar');
+      assert.strictEqual(
+        actual.selenium,
+        'https://localhost/selenium-3.0.0-beta2/selenium-server-standalone-3.0.0-beta2.jar'
+      );
     });
 
     it('version 4 basic', async () => {
@@ -101,6 +106,38 @@ describe('compute-download-urls', () => {
         actual.selenium,
         'https://selenium-release.storage.googleapis.com/4.0-alpha-7/selenium-server-4.0.0-alpha-7.jar'
       );
+    });
+
+    it('generates URLs that respond successfully', async function () {
+      this.timeout(5000); // HTTP requests take a few seconds
+
+      const versionsExpectedToFail = ['3.150.0'];
+
+      let data;
+      try {
+        const releasesURL = 'https://api.github.com/repos/SeleniumHQ/selenium/releases';
+        data = await got(releasesURL).json();
+      } catch (e) {
+        // Likely no internet connection so skip but output error to help
+        // debug in case something else.
+        console.debug(e);
+        return this.skip();
+      }
+
+      const versions = data.map((release) => release.tag_name.replace(/^selenium-/, ''));
+      const checks = versions.map(async (version) => {
+        if (versionsExpectedToFail.includes(version)) return;
+
+        const urls = await computeDownloadUrls({
+          seleniumVersion: version,
+          seleniumBaseURL: defaults.baseURL,
+          drivers: {},
+        });
+
+        const { statusCode } = await got(urls.selenium, { method: 'HEAD', throwHttpErrors: false });
+        assert.strictEqual(statusCode, 200, `URL for Selenium ${version} does not look valid`);
+      });
+      await Promise.all(checks);
     });
   });
 

--- a/test/compute-download-urls-test.js
+++ b/test/compute-download-urls-test.js
@@ -36,7 +36,7 @@ describe('compute-download-urls', () => {
         drivers: {},
       });
 
-      assert.strictEqual(actual.selenium, 'https://localhost/1.0/selenium-server-standalone-1.0.jar');
+      assert.strictEqual(actual.selenium, 'https://localhost/selenium-1.0/selenium-server-standalone-1.0.jar');
     });
 
     it('version with patch', async () => {
@@ -46,7 +46,7 @@ describe('compute-download-urls', () => {
         drivers: {},
       });
 
-      assert.strictEqual(actual.selenium, 'https://localhost/1.0/selenium-server-standalone-1.0.1.jar');
+      assert.strictEqual(actual.selenium, 'https://localhost/selenium-1.0.1/selenium-server-standalone-1.0.1.jar');
     });
 
     it('version with beta string', async () => {
@@ -56,7 +56,7 @@ describe('compute-download-urls', () => {
         drivers: {},
       });
 
-      assert.strictEqual(actual.selenium, 'https://localhost/3.0-beta2/selenium-server-standalone-3.0.0-beta2.jar');
+      assert.strictEqual(actual.selenium, 'https://localhost/selenium-3.0.0-beta2/selenium-server-standalone-3.0.0-beta2.jar');
     });
 
     it('version 4 basic', async () => {
@@ -291,7 +291,6 @@ describe('compute-download-urls', () => {
         };
 
         const actual = await computeDownloadUrls(opts);
-        console.log(actual.firefox);
         assert(actual.firefox.indexOf('macos.') > 0);
       });
 


### PR DESCRIPTION
This should fix #659.

I divided this up into two commits. The first is just the simple fix along with an update to the unit tests to match.

But obviously the tests were passing just fine previously even though the URLs were invalid. Therefore the second commit ups our testing so we are doing a smoke test against the URL for every released version (according to Github). This should prevent a similar regression in the future.

Since this test uses the internet I did make it bail out and skip the test if it can't get that release list under the idea that the developer is disconnected. I had to increase the timeout a bit for that test. On my machine it took a bit over 2 seconds to get that release list and check each URL. 5 seconds should give padding if someone has a slow connection.

If this sort of integration test is not something you want in the test suite feel free to pop the commit off via a rebase and just merge the first one.

Also I did make sure to run the linter and updated my syntax to make the nanny happy so hopefully should avoid the issues I got last time.