### PR TITLE
Fix Conditional HTTP Requests

### DIFF
--- a/lib/install-utils.js
+++ b/lib/install-utils.js
@@ -1,6 +1,5 @@
 const tarStream = require('tar-stream');
 const os = require('os');
-const crypto = require('crypto');
 const mkdirp = require('mkdirp');
 const path = require('path');
 const yauzl = require('yauzl');
@@ -80,37 +79,14 @@ async function setDriverFilePermissions(where) {
   }
 }
 
-async function checksum(filepath) {
-  if (!fs.existsSync(filepath)) {
-    return null;
-  }
-
-  return new Promise((resolve, reject) => {
-    const hash = crypto.createHash('md5');
-    const stream = fs.createReadStream(filepath);
-    stream.on('error', reject);
-    stream.on('data', (data) => hash.update(data, 'utf8'));
-    stream.on('end', () => resolve(hash.digest('hex')));
-  });
-}
-
-async function isUpToDate(url, requestOpts, hash) {
-  if (!hash) {
+async function isUpToDate(url, requestOpts, etag) {
+  if (!etag) {
     return false;
-  }
-
-  /**
-   * the msedgedriver.azureedge.net endpoint to download edgedriver
-   * doesn't support the "If-None-Match" header and will always re-download
-   * it. To prevent this we always assume it is the latest
-   */
-  if (hash && url.includes('edgedriver')) {
-    return true;
   }
 
   const options = merge({}, requestOpts, {
     headers: {
-      'If-None-Match': `"${hash}"`,
+      'If-None-Match': etag,
     },
   });
   try {
@@ -256,7 +232,6 @@ module.exports = {
   createDirs,
   setDriverFilePermissions,
   logInstallSummary,
-  checksum,
   isUpToDate,
   getTempFileName,
   uncompressDownloadedFile,

--- a/lib/install.js
+++ b/lib/install.js
@@ -197,12 +197,7 @@ async function install(_opts) {
   async function installSingleFile(from, to) {
     const stream = await getDownloadStream(from);
 
-    return new Promise((resolve, reject) =>
-      stream
-        .pipe(fs.createWriteStream(to))
-        .once('error', (err) => reject(logError('installSingleFile', err)))
-        .once('finish', resolve)
-    );
+    return writeDownloadStream(stream, to);
   }
 
   async function downloadInstallerFile(from, to) {
@@ -213,15 +208,7 @@ async function install(_opts) {
     const stream = await getDownloadStream(from);
     const installerFile = getTempFileName('installer.msi');
 
-    await new Promise((resolve, reject) => {
-      const msiWriteStream = fs
-        .createWriteStream(installerFile)
-        .once('error', (err) => reject(logError('downloadInstallerFile', err)));
-      stream.pipe(msiWriteStream);
-
-      msiWriteStream.once('finish', resolve);
-    });
-
+    await writeDownloadStream(stream, installerFile);
     return runInstaller(installerFile, from, to);
   }
 
@@ -248,33 +235,14 @@ async function install(_opts) {
   async function installGzippedFile(from, to) {
     const stream = await getDownloadStream(from);
 
-    // Store downloaded compressed file
-    await new Promise((resolve, reject) => {
-      const gzipWriteStream = fs
-        .createWriteStream(to)
-        .once('error', (err) => reject(logError('installGzippedFile', err)));
-      stream.pipe(gzipWriteStream);
-
-      gzipWriteStream.once('finish', resolve);
-    });
-
+    await writeDownloadStream(stream, to);
     return uncompressGzippedFile(from, to);
   }
 
   async function installZippedFile(from, to) {
     const stream = await getDownloadStream(from);
 
-    await new Promise((resolve, reject) => {
-      // Store downloaded compressed file
-      const zipWriteStream = fs
-        .createWriteStream(to)
-        .once('error', (err) => reject(logError('installZippedFile', err)));
-      stream.pipe(zipWriteStream);
-
-      // Uncompress downloaded file
-      zipWriteStream.once('finish', resolve);
-    });
-
+    await writeDownloadStream(stream, to);
     return uncompressDownloadedFile(to);
   }
 
@@ -317,6 +285,15 @@ async function install(_opts) {
           }
           throw new Error('Could not download ' + downloadUrl);
         });
+    });
+  }
+
+  async function writeDownloadStream(stream, to) {
+    await new Promise((resolve, reject) => {
+      const writeStream = fs.createWriteStream(to).once('error', (err) => reject(logError('writeDownloadStream', err)));
+      stream.pipe(writeStream);
+
+      writeStream.once('finish', resolve);
     });
   }
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-shadow */
 module.exports = install;
 
-const fs = require('fs');
+const { createWriteStream } = require('fs');
+const { writeFile } = require('fs/promises');
 const path = require('path');
 const got = require('got');
 const merge = require('lodash.merge');
@@ -208,7 +209,7 @@ async function install(_opts) {
     const stream = await getDownloadStream(from);
     const installerFile = getTempFileName('installer.msi');
 
-    await writeDownloadStream(stream, installerFile);
+    await writeDownloadStream(stream, installerFile, `${to}.etag`);
     return runInstaller(installerFile, from, to);
   }
 
@@ -288,13 +289,22 @@ async function install(_opts) {
     });
   }
 
-  async function writeDownloadStream(stream, to) {
-    await new Promise((resolve, reject) => {
-      const writeStream = fs.createWriteStream(to).once('error', (err) => reject(logError('writeDownloadStream', err)));
+  async function writeDownloadStream(stream, to, etagPath = `${to}.etag`) {
+    const writeEtagPromise = new Promise((resolve, reject) => {
+      stream.once('response', async (response) => {
+        await writeFile(etagPath, response.headers.etag);
+        resolve();
+      });
+    });
+
+    const writeFilePromise = new Promise((resolve, reject) => {
+      const writeStream = createWriteStream(to).once('error', (err) => reject(logError('writeDownloadStream', err)));
       stream.pipe(writeStream);
 
       writeStream.once('finish', resolve);
     });
+
+    return Promise.all([writeEtagPromise, writeFilePromise]);
   }
 }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -120,7 +120,7 @@ async function install(_opts) {
       etag = await readFile(`${opts.to}.etag`);
     } catch (err) {
       // ENOENT means not found which is ok. But anything else re-raise
-      if( err.code != 'ENOENT' ) throw err
+      if (err.code != 'ENOENT') throw err;
     }
     const isLatest = await isUpToDate(opts.from, requestOpts, etag);
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -2,7 +2,7 @@
 module.exports = install;
 
 const { createWriteStream } = require('fs');
-const { writeFile } = require('fs/promises');
+const { readFile, writeFile } = require('fs/promises');
 const path = require('path');
 const got = require('got');
 const merge = require('lodash.merge');
@@ -18,7 +18,6 @@ const {
   createDirs,
   setDriverFilePermissions,
   logInstallSummary,
-  checksum,
   isUpToDate,
   getTempFileName,
   uncompressGzippedFile,
@@ -116,8 +115,14 @@ async function install(_opts) {
   }
 
   async function onlyInstallMissingFiles(opts) {
-    const hash = await checksum(opts.to);
-    const isLatest = await isUpToDate(opts.from, requestOpts, hash);
+    let etag;
+    try {
+      etag = await readFile(`${opts.to}.etag`);
+    } catch (err) {
+      // ENOENT means not found which is ok. But anything else re-raise
+      if( err.code != 'ENOENT' ) throw err
+    }
+    const isLatest = await isUpToDate(opts.from, requestOpts, etag);
 
     // File already exists. Prevent download/installation.
     if (isLatest) {
@@ -292,8 +297,12 @@ async function install(_opts) {
   async function writeDownloadStream(stream, to, etagPath = `${to}.etag`) {
     const writeEtagPromise = new Promise((resolve, reject) => {
       stream.once('response', async (response) => {
-        await writeFile(etagPath, response.headers.etag);
-        resolve();
+        try {
+          await writeFile(etagPath, response.headers.etag);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
       });
     });
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -2,7 +2,7 @@
 module.exports = install;
 
 const { createWriteStream } = require('fs');
-const { readFile, writeFile } = require('fs/promises');
+const { readFile, writeFile } = require('fs').promises;
 const path = require('path');
 const got = require('got');
 const merge = require('lodash.merge');

--- a/test/no-reinstall.js
+++ b/test/no-reinstall.js
@@ -8,13 +8,35 @@ describe('when files are installed', () => {
     const path = require('path');
     const targetDir = path.join(__dirname, '..', '.selenium');
     const selenium = require('..');
-    const origDirModifTime = fs.statSync(targetDir).mtime.getTime();
+
+    // Recursively find files in the given directory
+    function walk(dirname, files = []) {
+      fs.readdirSync(dirname).forEach((name) => {
+        const filepath = path.join(dirname, name);
+        if (fs.statSync(filepath).isDirectory()) {
+          walk(filepath, files);
+        } else {
+          files.push(filepath);
+        }
+      });
+      return files;
+    }
+    const installedFiles = walk(targetDir);
+
+    // Get last modified time of files that should already be installed in
+    // the .selenium directory.
+    const mtimes = installedFiles.reduce((acc, filepath) => {
+      acc[filepath] = fs.statSync(filepath).mtime.getTime();
+      return acc;
+    }, {});
 
     // Compare last modified time of files after running the installation
     // again. It shouldn't download any files, otherwise it fails.
     await selenium.install();
-    const currentDirModifTime = fs.statSync(targetDir).mtime.getTime();
-    const isModified = currentDirModifTime > origDirModifTime;
+
+    const isModified = !installedFiles.every((filepath) => {
+      return mtimes[filepath] === fs.statSync(filepath).mtime.getTime();
+    });
 
     assert.strictEqual(isModified, false, 'It should not have reinstalled files');
   });


### PR DESCRIPTION
This should resolve #658.

I realized it was also downloading the Selenium jar file since that is now also hosted on Github and therefore the assumed etag generation of MD5 was not the proper request. This also allowed me to remove the special MSEdge as the fault was not with their system but the requests this software was making (they are also not using MD5).

Since there are a number of changes I have broken it down the following pieces to make it easier to digest:

* 3182e23 - The first order of business is to have a failing test. Fortunately there was already a test just for this issue. Unfortunately it was passing when it should not be. ☹️  I looked at the git history and it appears it was originally correct but in 2da8f60 it was updated to be incorrect (and basically always pass). The commit message doesn't provide much info but my best guess is that the developer thought the top-level folder would update its timestamp if any file in that folder or sub-folder updated. The original tree-walking is the right behavior. For the most part I just restored the previous code, updating the style a bit for the ever evolving JS language. With this commit I now have a failing test.
* 3e84c96 - This doesn't change any behavior but it [DRY](https://en.wikipedia.org/wiki/Don't_repeat_yourself)s up some repeating code. By removing the repetition I have a single place I can modify to add my new etag saving.
* 2379452 - This updates that newly created common code to actually save the etag for each file it downloads.
* 649355e - This updates the conditional HTTP request portion of the code to use our new etag if they exist. If the etag does not exist then it will end up downloading the file. This means people who upgrade will likely re-download everything once.