### PR TITLE
bug #617 improve timeouts for GOT utils

### DIFF
--- a/lib/check-started.js
+++ b/lib/check-started.js
@@ -16,6 +16,7 @@ async function checkStarted(selenium, seleniumStatusUrl) {
 
   const DEFAULT_SELENUIM_CHECK_STARTED_TIMEOUT = 60000; // 1minute
   const DEFAULT_SELENUIM_CHECK_STARTED_PAUSE = 500; // 0.5 second
+  const GOT_STARTUP_TIMEOUT = 10000; // 10 secs
 
   const serverStartupTimeoutMS =
     parseInt(process.env.SELENUIM_CHECK_STARTED_TIMEOUT, 10) || DEFAULT_SELENUIM_CHECK_STARTED_TIMEOUT;
@@ -25,8 +26,12 @@ async function checkStarted(selenium, seleniumStatusUrl) {
 
   const gotOptions = {
     responseType: 'json',
-    timeout: serverStartupTimeoutMS,
-    retry: 0,
+    timeout: {
+      request: GOT_STARTUP_TIMEOUT,
+    },
+    retry: {
+      limit: 0,
+    },
   };
 
   let attempts = serverStartupTimeoutMS / serverStartupPauseMs;

--- a/lib/check-started.js
+++ b/lib/check-started.js
@@ -14,16 +14,25 @@ async function checkStarted(selenium, seleniumStatusUrl) {
     selenium.stderr.on('data', (d) => (cpState.stderr += d.toString()));
   }
 
-  const options = {
+  const DEFAULT_SELENUIM_CHECK_STARTED_TIMEOUT = 60000; // 1minute
+  const DEFAULT_SELENUIM_CHECK_STARTED_PAUSE = 500; // 0.5 second
+
+  const serverStartupTimeoutMS =
+    parseInt(process.env.SELENUIM_CHECK_STARTED_TIMEOUT, 10) || DEFAULT_SELENUIM_CHECK_STARTED_TIMEOUT;
+
+  const serverStartupPauseMs =
+    parseInt(process.env.SELENUIM_CHECK_STARTED_PAUSE, 10) || DEFAULT_SELENUIM_CHECK_STARTED_PAUSE;
+
+  const gotOptions = {
     responseType: 'json',
-    timeout: 10000,
+    timeout: serverStartupTimeoutMS,
     retry: 0,
   };
 
-  let attempts = 29;
+  let attempts = serverStartupTimeoutMS / serverStartupPauseMs;
   const startTime = Date.now();
-  while (attempts > 0 && Date.now() - startTime < 30000) {
-    await sleep(500);
+  while (attempts > 0 && Date.now() - startTime < serverStartupTimeoutMS) {
+    await sleep(serverStartupPauseMs);
     attempts--;
 
     if (cpState.exited) {
@@ -34,7 +43,7 @@ async function checkStarted(selenium, seleniumStatusUrl) {
 
     try {
       // server has one minute to start
-      await got(seleniumStatusUrl, options);
+      await got(seleniumStatusUrl, gotOptions);
       selenium.removeListener('exit', errorIfNeverStarted);
       return null;
     } catch (err) {


### PR DESCRIPTION
After more details testing found that timeout for got utils and timeout for startup checks should be different. 
Also in gotOptions timeout should be `object` according to [documentation](https://github.com/sindresorhus/got/blob/6f5c7ce1233c7a28fed12d64766fa19e8eb3b345/documentation/6-timeout.md) 