### PR TITLE
Fix conditional driver loading

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -42,8 +42,6 @@ async function start(_opts) {
     !hasParam(opts.seleniumArgs, 'standalone') &&
     !hasParam(opts.seleniumArgs, 'distributor')
   ) {
-    opts.seleniumArgs.unshift('false');
-    opts.seleniumArgs.unshift('--detect-drivers');
     opts.seleniumArgs.unshift('standalone');
   }
 
@@ -90,26 +88,36 @@ async function start(_opts) {
    */
   if (fsPaths.chrome) {
     args.push('-Dwebdriver.chrome.driver=' + fsPaths.chrome.installPath);
+    opts.seleniumArgs.push('-I');
+    opts.seleniumArgs.push('chrome');
   }
 
   if (process.platform === 'win32' && fsPaths.ie) {
     args.push('-Dwebdriver.ie.driver=' + fsPaths.ie.installPath);
+    opts.seleniumArgs.push('-I');
+    opts.seleniumArgs.push('internet explorer');
   } else {
     delete fsPaths.ie;
   }
 
   if (process.platform === 'win32' && fsPaths.edge) {
     args.push('-Dwebdriver.edge.driver=' + fsPaths.edge.installPath);
+    opts.seleniumArgs.push('-I');
+    opts.seleniumArgs.push('edge');
   } else {
     delete fsPaths.edge;
   }
 
   if (fsPaths.firefox) {
     args.push('-Dwebdriver.gecko.driver=' + fsPaths.firefox.installPath);
+    opts.seleniumArgs.push('-I');
+    opts.seleniumArgs.push('firefox');
   }
 
   if (fsPaths.chromiumedge) {
     args.push('-Dwebdriver.edge.driver=' + fsPaths.chromiumedge.installPath);
+    opts.seleniumArgs.push('-I');
+    opts.seleniumArgs.push('edge');
   } else {
     delete fsPaths.chromiumedge;
   }

--- a/lib/start.js
+++ b/lib/start.js
@@ -27,6 +27,10 @@ async function start(_opts) {
     opts.seleniumArgs = [];
   }
 
+  if (!opts.spawnOptions) {
+    opts.spawnOptions = {};
+  }
+
   if (!opts.version) {
     opts.version = defaultConfig.version;
   }
@@ -38,6 +42,8 @@ async function start(_opts) {
     !hasParam(opts.seleniumArgs, 'standalone') &&
     !hasParam(opts.seleniumArgs, 'distributor')
   ) {
+    opts.seleniumArgs.unshift('false');
+    opts.seleniumArgs.unshift('--detect-drivers');
     opts.seleniumArgs.unshift('standalone');
   }
 
@@ -115,6 +121,10 @@ async function start(_opts) {
   const seleniumStatusUrl = statusUrl.getSeleniumStatusUrl(args, opts);
   if (await isPortReachable(seleniumStatusUrl.port, { timeout: 100 })) {
     throw new Error(`Port ${seleniumStatusUrl.port} is already in use.`);
+  }
+
+  if (!opts.spawnOptions.stdio) {
+    opts.spawnOptions.stdio = 'ignore';
   }
 
   debug('Spawning Selenium Server process', opts.javaPath, args);


### PR DESCRIPTION
This is a follow-up to #660.

The "should start with the given drivers" test was not passing for me. I believe this is because `--detect-drivers` is auto-loading drivers it can find on some peoples system but on my system there are no drivers in the PATH so it causes an error by the JAR file. Either that or it is failing for everybody and the JAR file changed behavior recently to throw an error when no drivers can be found and `--detect-drivers` is enabled.

In #660, I thought `--detect-drivers` only did auto-detection and since we were specifying the path to all drivers it should not be needed. By setting that to false it caused the tests to pass. Unfortunately as @wyhmichael correctly pointed out that option will stop all loading of drivers not just the ones auto-detected. We should be using the `-I` option to indicate what drivers to load.

This PR does 3 things:

* 6503855 reverts the revert of my original work. I wanted to do this because that work had other fixes we want to keep (stdio fixes) as well as I would like the wrong code to initially be in the system so we can update the test suite to detect the problem I created.
* 7f789b3 makes that update to the test suite to detect the problem. Instead of examining the arguments to see what was asked to be loaded it examines the Selenium output to see what was actually loaded. By making this change my wrong code is no longer passing.
* 3fcbe26 wraps this up by removing my wrong code and replacing it with the `-I` arguments that I think make the right code.

Commit messages have a bit more info but hopefully this should work better than my last attempt.