### PR TITLE
feat: Allow Safari to be launched

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -122,6 +122,16 @@ async function start(_opts) {
     delete fsPaths.chromiumedge;
   }
 
+  // Add Safari support only when on macOS
+  // (Safari does exist on Windows, but it is no longer supported. And while it seems like it's possible
+  // to install Safari on Linux, apparently you need to use a compatability layer like WINE. This code could
+  // theoretically be updated to support other OSes besides macOS)
+  if (process.platform === 'darwin') {
+    // SafariDriver is already bundled with Safari, so there's nothing that needs to be downloaded
+    opts.seleniumArgs.push('-I');
+    opts.seleniumArgs.push('safari');
+  }
+
   args.push(...opts.javaArgs, '-jar', fsPaths.selenium.installPath, ...opts.seleniumArgs);
 
   await checkPathsExistence(Object.keys(fsPaths).map((name) => fsPaths[name].installPath));


### PR DESCRIPTION
#670 changed the launching of `selenium-server.jar` to only allow certain browsers. Although there is no driver that needs downloading for Safari (apparently SafariDriver is available on all Macs), we should still allow Safari to be launched.

Testing:
- Verified that I can now request `browserName: 'safari'` and that Safari loads on my Mac