### PR TITLE
Update compute-download-urls.js

### DIFF
--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -114,7 +114,7 @@ function getChromeDriverArchitecture() {
   if (process.platform === 'linux') {
     platform = 'linux64';
   } else if (process.platform === 'darwin') {
-    platform = 'mac64' + (process.arch === 'arm64' ? '_m1' : '');
+    platform = process.arch === 'arm64' ? 'mac_arm64' : 'mac64';
   } else {
     platform = 'win32';
   }


### PR DESCRIPTION
updated platform to handle M1 MacBooks new chromedriver zip file naming convention.  "mac_arm64"