### PR TITLE
Use Mac arm64 EdgeDriver when available

### DIFF
--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -101,7 +101,7 @@ async function computeDownloadUrls(opts) {
         urls.chromiumedge,
         opts.drivers.chromiumedge.baseURL,
         opts.drivers.chromiumedge.version,
-        getChromiumEdgeDriverArchitecture(opts.drivers.chromiumedge.arch)
+        getChromiumEdgeDriverArchitecture(opts.drivers.chromiumedge.arch, opts.drivers.chromiumedge.version)
       );
   }
 
@@ -182,13 +182,18 @@ function getEdgeDriverUrl(version) {
   return release.url;
 }
 
-function getChromiumEdgeDriverArchitecture(wantedArchitecture) {
+function getChromiumEdgeDriverArchitecture(wantedArchitecture, version) {
   let platform;
 
   if (process.platform === 'linux') {
     platform = 'linux64';
   } else if (process.platform === 'darwin') {
-    platform = 'mac64';
+    if (process.arch === 'arm64') {
+      const [major] = version.split('.');
+      platform = parseInt(major, 10) > 104 ? 'mac64_m1' : 'mac64';
+    } else {
+      platform = 'mac64';
+    }
   } else if (wantedArchitecture === 'x32') {
     platform = 'win32';
   } else {

--- a/test/compute-download-urls-test.js
+++ b/test/compute-download-urls-test.js
@@ -544,6 +544,28 @@ describe('compute-download-urls', () => {
         const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.chromiumedge, 'https://localhost/86.0.600.0/edgedriver_mac64.zip');
       });
+
+      it('Use `mac64` on arm64 before Edge 105', async () => {
+        opts.drivers.chromiumedge = {
+          baseURL: 'https://localhost',
+          version: '104.0.1293.70',
+          arch: 'arm64',
+        };
+
+        const actual = await computeDownloadUrls(opts);
+        assert.strictEqual(actual.chromiumedge, 'https://localhost/104.0.1293.70/edgedriver_mac64.zip');
+      });
+
+      it('Use `mac64_m1` on arm64 starting from Edge 105', async () => {
+        opts.drivers.chromiumedge = {
+          baseURL: 'https://localhost',
+          version: '105.0.1343.34',
+          arch: 'arm64',
+        };
+
+        const actual = await computeDownloadUrls(opts);
+        assert.strictEqual(actual.chromiumedge, 'https://localhost/105.0.1343.34/edgedriver_mac64_m1.zip');
+      });
     });
 
     describe('win', () => {


### PR DESCRIPTION
I had an issue yesterday downloading the latest Chromium EdgeDriver on my M1 MacBook Air from a fresh install. It turns out that the latest EdgeDriver version had only been released for Linux. Seemingly Microsoft releases each different OS versions one at a time, not updating everything all at once. Even this morning, I see that selenium-standalone cannot download the latest version, it uses the fallback version 96.0.1054.34 even though I can manually download the latest versions from https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/

I do not have a solution for that (maybe I should enter a bug about the fallback mechanism being suboptimal?), but while investigating, I realized that selenium-standalone is not downloading the arm64 version of EdgeDriver for arm64 Macs as it does for Chrome.

Here is a PR to solve this. I noticed that the default-downloads-test.js Unit Test had no section for Chromium Edge, but trying to add one with the piece by piece update strategy from Microsoft was very difficult (due to the issue above about always triggering the fallback mechanism). In the end, I gave up adding a test for Chromium Edge in default-downloads-test.js, maybe that's the reason why there wasn't one to start with as it seems very difficult to make it work consistently?

If you have any guidance about improving that fallback process (and maybe we can't, I guess. It all depends on how Microsoft handles their release of EdgeDriver) maybe I can take a stab at it?

One last thing, it seems that for each major version of Chromium EdgeDriver, the early releases don't necessarily have a arm64/"m1" Mac release, but the later releases under that same major version do.  So the cutoff of when to try to grab the arm64/"m1" release was pretty much arbitrary. I decided that major version 105 and up is ok, but if you have a better idea, I am all ears!