### PR TITLE
Armk/selenium3 backward com

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,7 @@ async function myFn() {
   await selenium.install({
     // check for more recent versions of selenium here:
     // https://selenium-release.storage.googleapis.com/index.html
-    version: '3.141.59',
+    version: process.env.SELENIUM_VERSION || '4.4.0',
     baseURL: 'https://selenium-release.storage.googleapis.com',
     drivers: {
       chrome: {
@@ -120,3 +120,8 @@ If you're getting this error, it means that you didn't shut down the server succ
 ```shell
 pkill -f selenium-standalone
 ```
+
+## set selenium-standalone version as node env parameter
+
+You can set `process.env.SELENIUM_VERSION=3.141.59` before starting selenium-standalone
+Default values are here: [lib/default-config.js](../lib/default-config.js)

--- a/docs/API.md
+++ b/docs/API.md
@@ -121,7 +121,7 @@ If you're getting this error, it means that you didn't shut down the server succ
 pkill -f selenium-standalone
 ```
 
-## set selenium-standalone version as node env parameter
+## Set `selenium-standalone` Version as NodeJS environment parameter
 
 You can set any version by `process.env.SELENIUM_VERSION=3.141.59` before starting selenium-standalone  
 Default values are here: [lib/default-config.js](../lib/default-config.js)

--- a/docs/API.md
+++ b/docs/API.md
@@ -123,5 +123,4 @@ pkill -f selenium-standalone
 
 ## Set `selenium-standalone` Version as NodeJS environment parameter
 
-You can set any version by `process.env.SELENIUM_VERSION=3.141.59` before starting selenium-standalone  
-Default values are here: [lib/default-config.js](../lib/default-config.js)
+You can set any version by `process.env.SELENIUM_VERSION=3.141.59` before starting selenium-standalone. Default values are here: [lib/default-config.js](../lib/default-config.js)

--- a/docs/API.md
+++ b/docs/API.md
@@ -123,5 +123,5 @@ pkill -f selenium-standalone
 
 ## set selenium-standalone version as node env parameter
 
-You can set `process.env.SELENIUM_VERSION=3.141.59` before starting selenium-standalone
+You can set any version by `process.env.SELENIUM_VERSION=3.141.59` before starting selenium-standalone  
 Default values are here: [lib/default-config.js](../lib/default-config.js)

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1,7 +1,7 @@
 module.exports = () => {
   const config = {
     baseURL: 'https://github.com/SeleniumHQ/selenium/releases/download',
-    version: '4.0.0',
+    version: process.env.SELENIUM_VERSION || '4.4.0',
     drivers: {
       chrome: {
         version: 'latest',

--- a/lib/get-selenium-status-url.js
+++ b/lib/get-selenium-status-url.js
@@ -48,9 +48,9 @@ exports.getSeleniumStatusUrl = function (seleniumArgs, opts) {
   const nodeConfigArg = seleniumArgs.indexOf('-nodeConfig');
 
   // args prefix differs for selenium3 and selenium4
-  let argsPrefix = '--';
-  if (!isSelenium4(opts.version)) {
-    argsPrefix = '-';
+  let argsPrefix = '-';
+  if (isSelenium4(opts.version)) {
+    argsPrefix = '--';
   }
   const portArg = seleniumArgs.indexOf(`${argsPrefix}port`);
   const hostArg = seleniumArgs.indexOf(`${argsPrefix}host`);

--- a/lib/start.js
+++ b/lib/start.js
@@ -88,36 +88,46 @@ async function start(_opts) {
    */
   if (fsPaths.chrome) {
     args.push('-Dwebdriver.chrome.driver=' + fsPaths.chrome.installPath);
-    opts.seleniumArgs.push('-I');
-    opts.seleniumArgs.push('chrome');
+    if (isSelenium4(opts.version)) {
+      opts.seleniumArgs.push('-I');
+      opts.seleniumArgs.push('chrome');
+    }
   }
 
   if (process.platform === 'win32' && fsPaths.ie) {
     args.push('-Dwebdriver.ie.driver=' + fsPaths.ie.installPath);
-    opts.seleniumArgs.push('-I');
-    opts.seleniumArgs.push('internet explorer');
+    if (isSelenium4(opts.version)) {
+      opts.seleniumArgs.push('-I');
+      opts.seleniumArgs.push('internet explorer');
+    }
   } else {
     delete fsPaths.ie;
   }
 
   if (process.platform === 'win32' && fsPaths.edge) {
     args.push('-Dwebdriver.edge.driver=' + fsPaths.edge.installPath);
-    opts.seleniumArgs.push('-I');
-    opts.seleniumArgs.push('edge');
+    if (isSelenium4(opts.version)) {
+      opts.seleniumArgs.push('-I');
+      opts.seleniumArgs.push('edge');
+    }
   } else {
     delete fsPaths.edge;
   }
 
   if (fsPaths.firefox) {
     args.push('-Dwebdriver.gecko.driver=' + fsPaths.firefox.installPath);
-    opts.seleniumArgs.push('-I');
-    opts.seleniumArgs.push('firefox');
+    if (isSelenium4(opts.version)) {
+      opts.seleniumArgs.push('-I');
+      opts.seleniumArgs.push('firefox');
+    }
   }
 
   if (fsPaths.chromiumedge) {
     args.push('-Dwebdriver.edge.driver=' + fsPaths.chromiumedge.installPath);
-    opts.seleniumArgs.push('-I');
-    opts.seleniumArgs.push('edge');
+    if (isSelenium4(opts.version)) {
+      opts.seleniumArgs.push('-I');
+      opts.seleniumArgs.push('edge');
+    }
   } else {
     delete fsPaths.chromiumedge;
   }
@@ -126,7 +136,7 @@ async function start(_opts) {
   // (Safari does exist on Windows, but it is no longer supported. And while it seems like it's possible
   // to install Safari on Linux, apparently you need to use a compatability layer like WINE. This code could
   // theoretically be updated to support other OSes besides macOS)
-  if (process.platform === 'darwin') {
+  if (process.platform === 'darwin' && isSelenium4(opts.version)) {
     // SafariDriver is already bundled with Safari, so there's nothing that needs to be downloaded
     opts.seleniumArgs.push('-I');
     opts.seleniumArgs.push('safari');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "DEBUG=selenium-standalone:* ./bin/selenium-standalone install && DEBUG=selenium-standalone:* ./bin/selenium-standalone start",
-    "test": "./bin/selenium-standalone install && mocha",
+    "test": "export SELENIUM_VERSION=4.4.0&& ./bin/selenium-standalone install && mocha && export SELENIUM_VERSION=3.141.59&& ./bin/selenium-standalone install && mocha 'test/programmatic.js'",
     "docker:build": "run-s docker:build:*",
     "docker:build:latest": "docker build -t webdriverio/${npm_package_name}:latest --cache-from webdriverio/${npm_package_name}:latest .",
     "docker:build:tag": "docker build -t webdriverio/${npm_package_name}:${npm_package_version} --cache-from webdriverio/${npm_package_name}:${npm_package_version} .",

--- a/test/programmatic.js
+++ b/test/programmatic.js
@@ -45,6 +45,19 @@ describe('programmatic use', function () {
       });
   };
 
+  const testStartSelenium3 = function (done, options, callback) {
+    const selenium = require('../');
+    selenium
+      .start(options)
+      .catch(done)
+      .then((cp) => {
+        cp.kill();
+        if (callback(cp) !== false) {
+          done();
+        }
+      });
+  };
+
   it('should install', (done) => {
     testInstall(done, {}, (log) => {
       if (!containsChrome(log)) {
@@ -63,53 +76,103 @@ describe('programmatic use', function () {
     });
   });
 
-  it('should start', (done) => {
-    testStart(done, {}, (log) => {
-      if (!containsChrome(log)) {
-        done(new Error('Chrome driver should be loaded'));
-        return false;
-      }
-    });
+  it(`should start`, (done) => {
+    if (process.env.SELENIUM_VERSION.includes('3.141.59')) {
+      testStartSelenium3(done, {}, (cp) => {
+        if (cp.spawnargs && !cp.spawnargs.some(containsChrome)) {
+          done(new Error('Chrome driver should be loaded'));
+          return false;
+        }
+      });
+    } else {
+      testStart(done, {}, (log) => {
+        if (!containsChrome(log)) {
+          done(new Error('Chrome driver should be loaded'));
+          return false;
+        }
+      });
+    }
   });
 
   it('should start with custom seleniumArgs', (done) => {
-    testStart(done, { seleniumArgs: ['--port', '12345'] }, (log) => {
-      if (!containsChrome(log)) {
-        done(new Error('Chrome driver should be loaded'));
-        return false;
-      }
-    });
+    if (process.env.SELENIUM_VERSION.includes('3.141.59')) {
+      testStartSelenium3(done, { seleniumArgs: ['-port', '12345'] }, (cp) => {
+        if (cp.spawnargs && !cp.spawnargs.some(containsChrome)) {
+          done(new Error('Chrome driver should be loaded'));
+          return false;
+        }
+      });
+    } else {
+      testStart(done, { seleniumArgs: ['--port', '12345'] }, (log) => {
+        if (!containsChrome(log)) {
+          done(new Error('Chrome driver should be loaded'));
+          return false;
+        }
+      });
+    }
   });
 
   it('should start with the given drivers', (done) => {
-    testStart(done, { drivers: { firefox: {} } }, (log) => {
-      if (containsChrome(log)) {
-        done(new Error('Chrome driver should not be loaded'));
-        return false;
-      }
-    });
-  });
-
-  it('should start and merge drivers', (done) => {
-    const options = { seleniumArgs: ['--port', '4445'], drivers: { chrome: {} } };
-    testStart(done, options, (log) => {
-      if (!containsChrome(log)) {
-        done(new Error('Chrome driver should be loaded'));
-        return false;
-      }
-    });
-  });
-
-  it('should start with singleDriverStart options', (done) => {
-    testStart(
-      done,
-      { singleDriverStart: 'firefox', drivers: { chrome: {}, firefox: {} }, seleniumArgs: ['--port', '4446'] },
-      (log) => {
+    if (process.env.SELENIUM_VERSION.includes('3.141.59')) {
+      testStartSelenium3(done, { drivers: { firefox: {} } }, (cp) => {
+        if (cp.spawnargs && cp.spawnargs.some(containsChrome)) {
+          done(new Error('Chrome driver should be loaded'));
+          return false;
+        }
+      });
+    } else {
+      testStart(done, { drivers: { firefox: {} } }, (log) => {
         if (containsChrome(log)) {
           done(new Error('Chrome driver should not be loaded'));
           return false;
         }
-      }
-    );
+      });
+    }
+  });
+
+  it('should start and merge drivers', (done) => {
+    if (process.env.SELENIUM_VERSION.includes('3.141.59')) {
+      const options = { seleniumArgs: ['-port', '4445'], drivers: { chrome: {} } };
+      testStartSelenium3(done, options, (cp) => {
+        if (cp.spawnargs && !cp.spawnargs.some(containsChrome)) {
+          done(new Error('Chrome driver should be loaded'));
+          return false;
+        }
+      });
+    } else {
+      const options = { seleniumArgs: ['--port', '4445'], drivers: { chrome: {} } };
+      testStart(done, options, (log) => {
+        if (!containsChrome(log)) {
+          done(new Error('Chrome driver should be loaded'));
+          return false;
+        }
+      });
+    }
+  });
+
+  it('should start with singleDriverStart options', (done) => {
+    if (process.env.SELENIUM_VERSION.includes('3.141.59')) {
+      testStartSelenium3(
+        done,
+        { singleDriverStart: 'firefox', drivers: { chrome: {}, firefox: {} }, seleniumArgs: ['-port', '4446'] },
+        (cp) => {
+          if (cp.spawnargs && cp.spawnargs.some(containsChrome)) {
+            done(new Error('Chrome driver should be loaded'));
+            return false;
+          }
+        }
+      );
+    } else {
+      testStart(
+        done,
+        { singleDriverStart: 'firefox', drivers: { chrome: {}, firefox: {} }, seleniumArgs: ['--port', '4446'] },
+        (log) => {
+          if (containsChrome(log)) {
+            done(new Error('Chrome driver should not be loaded'));
+            return false;
+          }
+        }
+      );
+    }
   });
 });


### PR DESCRIPTION
fixes  #724 
problems:
* tests had hardcoded selenium 4 version, so no selenium3 tests were executed
* PR #670 added some code only selenium4 compatible
this PR fixes:
* npm script to run on both versions
* added `if isSelenium4...` for 670 PR changes
*  refactored `test/programmatic.js` to work with selenium3 and 4 (used old method for v3 and new for v4)
