### PR TITLE
Allows nested files to be unzipped, properly test for folders

### DIFF
--- a/lib/install-utils.js
+++ b/lib/install-utils.js
@@ -115,7 +115,8 @@ async function uncompressDownloadedFile(zipFilePath) {
         return reject(logError('uncompressDownloadedFile:yauzl.open', err));
       }
       zipFile.on('entry', (entry) => {
-        if (/.*\/.*/.test(entry.fileName)) {
+        if (fs.existsSync(entry.fileName)
+          && fs.lstatSync(entry.fileName).isDirectory()) {
           return; // ignore folders, i.e. release notes folder in edge driver zip
         }
         zipFile.openReadStream(entry, { autoClose: true }, function onOpenZipFileEntryReadStream(errRead, readStream) {
@@ -124,7 +125,7 @@ async function uncompressDownloadedFile(zipFilePath) {
           }
           const extractPath = path.join(
             path.dirname(zipFilePath),
-            isBrowserDriver(entry.fileName) ? path.basename(zipFilePath, '.zip') : entry.fileName
+            isBrowserDriver(entry.fileName) ? path.basename(zipFilePath, '.zip') : path.basename(entry.fileName)
           );
           const extractWriteStream = fs
             .createWriteStream(extractPath)

--- a/lib/install-utils.js
+++ b/lib/install-utils.js
@@ -115,8 +115,7 @@ async function uncompressDownloadedFile(zipFilePath) {
         return reject(logError('uncompressDownloadedFile:yauzl.open', err));
       }
       zipFile.on('entry', (entry) => {
-        if (fs.existsSync(entry.fileName)
-          && fs.lstatSync(entry.fileName).isDirectory()) {
+        if (fs.existsSync(entry.fileName) && fs.lstatSync(entry.fileName).isDirectory()) {
           return; // ignore folders, i.e. release notes folder in edge driver zip
         }
         zipFile.openReadStream(entry, { autoClose: true }, function onOpenZipFileEntryReadStream(errRead, readStream) {


### PR DESCRIPTION
Use case:
When downloading [Chrome Canary builds](https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json), the chromedriver file is nested within other folders.

This allows selenium-standalone to properly download and then extract these builds.
Without this, the chromedriver binary fails to extract, automation cannot proceed.

To test:

```ts
const drivers = {
	firefox: true,
	chrome: {
		version: '117.0.5858.0',
		arch: 'arm64'
		fullURL: `https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/117.0.5858.0/mac-arm64/chromedriver-mac-arm64.zip`,
	},
	chromiumedge: {
		version: 'latest',
		arch: process.arch,
		baseURL: 'https://msedgedriver.azureedge.net/',
	}
	
	
	// in wdio.conf.ts
	
	services: [
	['selenium-standalone', {

		installArgs: {
		  version: "4.10.0",
		  baseURL: "https://github.com/SeleniumHQ/selenium/releases/download",
		  drivers: drivers
		},

		args: {
		  version: "4.10.0",
		  seleniumArgs: ['--port', '4444'],
		  drivers: drivers
		},
	}]
	]
}

``` 
