### PR TITLE
fix/getArhType due to result of the detectBrowserPlatformInternal

### DIFF
--- a/lib/platformDetection.js
+++ b/lib/platformDetection.js
@@ -36,9 +36,13 @@ function getArhType(platform) {
   switch (platform) {
     case 'linux':
       return 'linux64';
+    case 'mac-arm64':
+      return 'mac-arm64';
     case 'mac_arm':
       return 'mac-arm64';
     case 'mac':
+      return 'mac-x64';
+    case 'mac-x64':
       return 'mac-x64';
     case 'win32':
       return 'win32';


### PR DESCRIPTION
I got this issue during downloading of the drivers, it seems to be a result of the detectBrowserPlatformInternal, it returns 
```'mac-arm64' : 'mac-x64'```, but those options are not available in getArhType switch/case 

```sh
selenium install:
from: https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.9.0/selenium-server-4.9.0.jar
to: /node_modules/selenium-standalone/.selenium/selenium-server/4.9.0/selenium-server.jar
---
chrome install:
from: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96//chromedriver-undefined.zip
to: /node_modules/selenium-standalone/.selenium/chromedriver/latest-mac-x64/chromedriver
---
File from https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.9.0/selenium-server-4.9.0.jar has already been downloaded

Error in "getDownloadStream". It may be due to the specified edge driver version edgedl is unavailable for current platform. Try downloading a different version of edge driver
See more details below:
404 https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/116.0.5845.96//chromedriver-undefined.zip
Response code 404 (Not Found)
/node_modules/selenium-standalone/lib/install.js:292
          throw new Error('Could not download ' + downloadUrl);
```

@christian-bromann can it be merged and published ASAP, please 
best regards, Dmytro
