### PR TITLE
checking downloaded file size with server size

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -27,7 +27,7 @@ module.exports = () => {
       },
       chromiumedge: {
         version: 'latest',
-        fallbackVersion: '96.0.1054.34',
+        fallbackVersion: '117.0.2045.55',
         arch: process.arch,
         onlyDriverArgs: [],
         baseURL: 'https://msedgedriver.azureedge.net',

--- a/lib/install-utils.js
+++ b/lib/install-utils.js
@@ -6,9 +6,9 @@ const yauzl = require('yauzl');
 const fs = require('fs');
 const zlib = require('zlib');
 const got = require('got');
-const merge = require('lodash.merge');
 const debug = require('debug')('selenium-standalone:install');
 const { logError } = require('./log-error');
+const md5 = require('md5');
 
 const installers = ['selenium', 'chrome', 'ie', 'firefox', 'edge', 'chromiumedge'];
 
@@ -79,30 +79,21 @@ async function setDriverFilePermissions(where) {
   }
 }
 
-async function isUpToDate(url, requestOpts, etag) {
-  if (!etag) {
+async function isUpToDate(url, file, pathToFile) {
+  if (!file) {
     return false;
   }
-
-  const options = merge({}, requestOpts, {
-    headers: {
-      'If-None-Match': etag,
-    },
-    timeout: 2500,
-  });
   try {
-    const response = await got(url, options);
-    return response.statusCode === 304;
-  } catch (err) {
-    if (err.response && err.response.statusCode === 304) {
+    const response = await got.head(url, {
+      timeout: 2500,
+    });
+    if (response.headers['content-length'] === `${fs.statSync(pathToFile).size}`) {
       return true;
     }
-    logError(
-      `Could not request headers from ${url}: ` +
-        (err.response ? err.response.statusCode : err.message) +
-        ', continue without checking for latest version.'
-    );
-    return true;
+    return response.headers.etag.includes(md5(file).toString());
+  } catch (err) {
+    logError(`Remote file size/hash in ${url} don't match with local file ${pathToFile}`);
+    return false;
   }
 }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -121,14 +121,16 @@ async function install(_opts) {
   }
 
   async function onlyInstallMissingFiles(opts) {
-    let etag;
+    let file;
     try {
-      etag = await readFile(`${opts.to}.etag`);
+      file = await readFile(opts.to);
     } catch (err) {
       // ENOENT means not found which is ok. But anything else re-raise
-      if (err.code != 'ENOENT') throw err;
+      if (err.code != 'ENOENT') {
+        throw err;
+      }
     }
-    const isLatest = await isUpToDate(opts.from, requestOpts, etag);
+    const isLatest = await isUpToDate(opts.from, file, opts.to);
 
     // File already exists. Prevent download/installation.
     if (isLatest) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "is-port-reachable": "^3.0.0",
         "lodash.mapvalues": "^4.6.0",
         "lodash.merge": "^4.6.2",
+        "md5": "^2.3.0",
         "minimist": "^1.2.5",
         "mkdirp": "^2.1.3",
         "progress": "2.0.3",
@@ -1219,6 +1220,14 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/check-error": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
@@ -1590,6 +1599,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/crypto-random-string": {
@@ -4762,6 +4779,21 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/md5/node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/mdast-util-find-and-replace": {
       "version": "1.1.1",
@@ -9928,6 +9960,11 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
+    },
     "check-error": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
@@ -10223,6 +10260,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
     "crypto-random-string": {
       "version": "2.0.0",
@@ -12589,6 +12631,23 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        }
+      }
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "is-port-reachable": "^3.0.0",
     "lodash.mapvalues": "^4.6.0",
     "lodash.merge": "^4.6.2",
+    "md5": "^2.3.0",
     "minimist": "^1.2.5",
     "mkdirp": "^2.1.3",
     "progress": "2.0.3",


### PR DESCRIPTION
Previous assumption with saving etag file haven't been worked. etag file has been saving before downloading any files that's why we didn't know, regarding files, have been downloaded it properly or not. If damaged file exist it can be deleted only manually for resolving the issue. The behaviour is leeding to blocking using the package.

Current approach 
1. It's compared content length from server and fs.stat().size from local file
2. if 1 step isn't valid it compares etag/md5 from server with md5 from local file.
3. if 1,2 step aren't valid it's downloading new files and rewrite it

related with https://github.com/webdriverio/selenium-standalone/issues/788