### PR TITLE
[fix] chromiumedge driver doesn't install on arm64 when user specifies "latest" for version

### DIFF
--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -210,7 +210,7 @@ async function chromiumEdgeBundleAvailable(opts) {
     urls.chromiumedge,
     opts.drivers.chromiumedge.baseURL,
     opts.drivers.chromiumedge.version,
-    getChromiumEdgeDriverArchitectureOld(opts.drivers.chromiumedge.platform, opts.drivers.chromedriver.version)
+    getChromiumEdgeDriverArchitectureOld(opts.drivers.chromiumedge.platform, opts.drivers.chromiumedge.version)
   );
   try {
     await got.head(url, { timeout: 10000 });

--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -210,7 +210,7 @@ async function chromiumEdgeBundleAvailable(opts) {
     urls.chromiumedge,
     opts.drivers.chromiumedge.baseURL,
     opts.drivers.chromiumedge.version,
-    getChromiumEdgeDriverArchitectureOld(opts.drivers.chromiumedge.platform)
+    getChromiumEdgeDriverArchitectureOld(opts.drivers.chromiumedge.platform, opts.drivers.chromedriver.version)
   );
   try {
     await got.head(url, { timeout: 10000 });


### PR DESCRIPTION
This fixes a small error when installing the chromium edge driver on the arm64 architecture. When the user selects "latest" for version, we were not passing the version info to the getChromiumEdgeDriverArchitectureOld function from chromiumEdgeBundleAvailable. This caused the function to fail silently, which would revert to the fallback version even if a later version was available.