### PR TITLE
fix: Update chromedriver download base url

### DIFF
--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -272,11 +272,7 @@ async function getLatestGeckodriver(opts, browserDriver, url) {
   }
 }
 
-function resolveDownloadUrl(
-  platform,
-  buildId,
-  baseUrl = 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing'
-) {
+function resolveDownloadUrl(platform, buildId, baseUrl = 'https://storage.googleapis.com/chrome-for-testing-public') {
   return `${baseUrl}/${resolveDownloadPath(platform, buildId).join('/')}`;
 }
 

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -8,7 +8,7 @@ module.exports = () => {
         channel: 'stable',
         arch: process.arch,
         onlyDriverArgs: [],
-        baseURL: 'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing',
+        baseURL: 'https://storage.googleapis.com/chrome-for-testing-public',
       },
       firefox: {
         version: 'latest',


### PR DESCRIPTION
Current url does not work for latest drivers: https://github.com/GoogleChromeLabs/chrome-for-testing/pull/108

```
404 https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/121.0.6167.184/mac-arm64/chromedriver-mac-arm64.zip
Response code 404 (Not Found)
```

Works well with the updated urls