### PR TITLE
refactor: Remove deprecated ::set-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Retrieve version
         run: |
-          echo "::set-output name=TAG_NAME::$(node -e 'console.log(require(`./package.json`).version)')"
+          echo "TAG_NAME=$(node -e 'console.log(require(`./package.json`).version)')" >> $GITHUB_OUTPUT
         id: version
 
       - name: Set up QEMU


### PR DESCRIPTION
### Proposed Changes

- Replace the deprecated `::set-output` ﻿workflow commands.
  See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.

