### PR TITLE
ci: Do not run workflow twice for a PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   linux:


### PR DESCRIPTION
### Problem

The workflows are run twice when we push to a PR branch. See https://github.com/webdriverio/selenium-standalone/pull/886/checks.

### Proposed Changes

* Only run the workflow once when we push to a PR branch

### Screenshots/Demo

The checks should not run for `(push)`, only `(pull_request)`.
