### PR TITLE
Fix error with axios and proxies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,32 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "11:00"
-  open-pull-requests-limit: 10
-  versioning-strategy: increase-if-necessary
-  ignore:
-    - dependency-name: "got"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "mocha"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "axios"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "husky"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "release-it"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "commander"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "eslint-plugin-prettier"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "eslint"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "execa"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "find-process"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "fkill"
-      update-types: ["version-update:semver-major"]
-    - dependency-name: "prettier"
-      update-types: ["version-update:semver-major"]
-
-
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "11:00"
+    open-pull-requests-limit: 10
+    versioning-strategy: increase-if-necessary
+    ignore:
+      - dependency-name: "got"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "mocha"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "husky"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "release-it"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "commander"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-plugin-prettier"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "execa"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "find-process"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "fkill"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "prettier"
+        update-types: ["version-update:semver-major"]

--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -10,7 +10,6 @@ const {
   getIeDriverArchitectureOld,
   getFirefoxDriverArchitectureOld,
 } = require('./platformDetection');
-const { default: axios } = require('axios');
 
 const urls = {
   selenium: '%s/%s/selenium-server-standalone-%s.jar',
@@ -278,7 +277,7 @@ function resolveDownloadPath(platform, buildId) {
 }
 
 async function getLastChromedriverVersionFromMajor(version) {
-  const response = await axios({
+  const response = await got({
     method: 'get',
     url: 'https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json',
     responseType: 'json',
@@ -286,7 +285,7 @@ async function getLastChromedriverVersionFromMajor(version) {
       'Content-Type': 'application/json',
     },
   });
-  const versionsWithMajor = response.data.versions.filter(
+  const versionsWithMajor = response.body.versions.filter(
     (f) =>
       validateMajorVersionPrefix(f.version) === validateMajorVersionPrefix(version) && 'chromedriver' in f.downloads
   );
@@ -300,7 +299,7 @@ async function getLastChromedriverVersionFromMajor(version) {
 }
 
 async function getLatestChromeVersion(possibleChanel) {
-  const response = await axios({
+  const response = await got({
     method: 'get',
     url: 'https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json',
     responseType: 'json',
@@ -308,10 +307,10 @@ async function getLatestChromeVersion(possibleChanel) {
       'Content-Type': 'application/json',
     },
   });
-  const channel = Object.keys(response.data.channels).find((i) => i.toLowerCase() === possibleChanel.toLowerCase());
+  const channel = Object.keys(response.body.channels).find((i) => i.toLowerCase() === possibleChanel.toLowerCase());
 
   try {
-    return response.data.channels[channel].version;
+    return response.body.channels[channel].version;
   } catch (err) {
     console.log();
     throw new Error(`channel can't be - ${possibleChanel}, possible only Stable, Beta, Dev, Canary`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "9.4.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.2",
         "commander": "^8.3.0",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.1",
@@ -1449,11 +1448,6 @@
         "retry": "0.13.1"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -1464,16 +1458,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/b4a": {
@@ -2137,17 +2121,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -2538,14 +2511,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/deprecation": {
@@ -3411,25 +3376,6 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -3450,19 +3396,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/form-data-encoder": {
@@ -5763,6 +5696,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5771,6 +5705,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -7404,7 +7339,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/ps-list": {
       "version": "7.2.0",
@@ -10707,26 +10643,11 @@
         "retry": "0.13.1"
       }
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
-    },
-    "axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
-      "requires": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "b4a": {
       "version": "1.6.4",
@@ -11153,14 +11074,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -11423,11 +11336,6 @@
         "escodegen": "^2.1.0",
         "esprima": "^4.0.1"
       }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "deprecation": {
       "version": "2.3.1",
@@ -12063,11 +11971,6 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
-    "follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
-    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -12085,16 +11988,6 @@
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
-      }
-    },
-    "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
       }
     },
     "form-data-encoder": {
@@ -13703,12 +13596,14 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -14876,7 +14771,8 @@
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "ps-list": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     }
   },
   "dependencies": {
-    "axios": "^1.6.2",
     "commander": "^8.3.0",
     "cross-spawn": "^7.0.3",
     "debug": "^4.3.1",

--- a/test/no-reinstall.js
+++ b/test/no-reinstall.js
@@ -22,6 +22,7 @@ describe('when files are installed', () => {
       return files;
     }
     const installedFiles = walk(targetDir);
+    console.log('*** installedFiles', installedFiles);
 
     // Get last modified time of files that should already be installed in
     // the .selenium directory.
@@ -29,12 +30,14 @@ describe('when files are installed', () => {
       acc[filepath] = fs.statSync(filepath).mtime.getTime();
       return acc;
     }, {});
+    console.log('*** mtimes', mtimes);
 
     // Compare last modified time of files after running the installation
     // again. It shouldn't download any files, otherwise it fails.
     await selenium.install();
 
     const isModified = !installedFiles.every((filepath) => {
+      console.log('*** mtimes', filepath, mtimes[filepath], fs.statSync(filepath).mtime.getTime());
       return mtimes[filepath] === fs.statSync(filepath).mtime.getTime();
     });
 

--- a/test/no-reinstall.js
+++ b/test/no-reinstall.js
@@ -22,7 +22,6 @@ describe('when files are installed', () => {
       return files;
     }
     const installedFiles = walk(targetDir);
-    console.log('*** installedFiles', installedFiles);
 
     // Get last modified time of files that should already be installed in
     // the .selenium directory.
@@ -30,14 +29,12 @@ describe('when files are installed', () => {
       acc[filepath] = fs.statSync(filepath).mtime.getTime();
       return acc;
     }, {});
-    console.log('*** mtimes', mtimes);
 
     // Compare last modified time of files after running the installation
     // again. It shouldn't download any files, otherwise it fails.
     await selenium.install();
 
     const isModified = !installedFiles.every((filepath) => {
-      console.log('*** mtimes', filepath, mtimes[filepath], fs.statSync(filepath).mtime.getTime());
       return mtimes[filepath] === fs.statSync(filepath).mtime.getTime();
     });
 


### PR DESCRIPTION
Remove axios dependecy due to this module has an error when the request is made via proxy (https://github.com/axios/axios/issues/4531#issuecomment-1608140085). 

Selenium-standalone has got http client that is better for this job.

`
2024-02-29T22:19:28.010Z - [selenium-standalone] [start] error installing version 4.17.0 selenium STACK: AxiosError: Request failed with status code 501
    at settle (/home/testrunner/run_test_env/TG-CHROM0-CCHD/sources/itests-orchard/node_modules/selenium-standalone/node_modules/axios/dist/node/axios.cjs:1967:12)
    at IncomingMessage.handleStreamEnd (/home/testrunner/run_test_env/TG-CHROM0-CCHD/sources/itests-orchard/node_modules/selenium-standalone/node_modules/axios/dist/node/axios.cjs:3066:11)
    at IncomingMessage.emit (node:events:526:35)
    at endReadableNT (node:internal/streams/readable:1359:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
    at Axios.request (/home/testrunner/run_test_env/TG-CHROM0-CCHD/sources/itests-orchard/node_modules/selenium-standalone/node_modules/axios/dist/node/axios.cjs:3877:41)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async getLastChromedriverVersionFromMajor (/home/testrunner/run_test_env/TG-CHROM0-CCHD/sources/itests-orchard/node_modules/selenium-standalone/lib/compute-download-urls.js:284:20)
    at async computeFsPaths (/home/testrunner/run_test_env/TG-CHROM0-CCHD/sources/itests-orchard/node_modules/selenium-standalone/lib/compute-fs-paths.js:17:23)
    at async Object.install (/home/testrunner/run_test_env/TG-CHROM0-CCHD/sources/itests-orchard/node_modules/selenium-standalone/lib/install.js:84:19)
    at async SeleniumStandalonePlugin.start (/home/testrunner/run_test_env/TG-CHROM0-CCHD/sources/itests-orchard/node_modules/@bbva-qe/orchard-selenium-standalone-plugin/lib/index.cjs:124:7)
    at async Promise.all (index 3)
`