### PR TITLE
fixed (find-process version, forced default port 9515 for chrome and edge driver), added exact match feature  

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
       - dependency-name: "execa"
         update-types: ["version-update:semver-major"]
       - dependency-name: "find-process"
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-patch"]
       - dependency-name: "fkill"
         update-types: ["version-update:semver-major"]
       - dependency-name: "prettier"

--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -294,7 +294,7 @@ async function getLastChromedriverVersionFromMajor(version) {
   if (exactMatch) {
     return exactMatch;
   }
-  const versionsWithMajor = response.body.versions.filter(
+  const versionsWithMajor = response.versions.filter(
     (f) =>
       validateMajorVersionPrefix(f.version) === validateMajorVersionPrefix(version) && 'chromedriver' in f.downloads
   );

--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -288,7 +288,13 @@ async function getLastChromedriverVersionFromMajor(version) {
       },
     },
   }).json();
-  const versionsWithMajor = response.versions.filter(
+
+  const exactMatch = response.versions.find((f) => f.version === version && 'chromedriver' in f.downloads);
+  // If exact match is found, return it
+  if (exactMatch) {
+    return exactMatch;
+  }
+  const versionsWithMajor = response.body.versions.filter(
     (f) =>
       validateMajorVersionPrefix(f.version) === validateMajorVersionPrefix(version) && 'chromedriver' in f.downloads
   );

--- a/lib/start.js
+++ b/lib/start.js
@@ -24,7 +24,7 @@ const { startDriver } = require('./driver-starter.js');
  *    fallbackVersion?: string,
  *    channel?: string,
  *    arch: NodeJS.Architecture,
- *    onlyDriverArgs: unknown[],
+ *    onlyDriverArgs: string[],
  *    baseURL: string
  * }>>} Drivers
  */
@@ -226,7 +226,7 @@ async function start(_opts) {
   if (opts.onlyDriver && opts.drivers[opts.onlyDriver]) {
     const chromeDriverProcess = await startDriver(
       fsPaths[opts.onlyDriver].installPath,
-      opts.drivers[opts.onlyDriver].onlyDriverArgs
+      [...opts.drivers[opts.onlyDriver].onlyDriverArgs, ...(!opts.drivers[opts.onlyDriver].onlyDriverArgs.some(item => item.includes('--port=')) && opts.onlyDriver !== 'firefox' ? [`--port=9515`] : [])]
     );
 
     return chromeDriverProcess;

--- a/lib/start.js
+++ b/lib/start.js
@@ -224,10 +224,13 @@ async function start(_opts) {
   debug('Spawning Selenium Server process', opts.javaPath, args);
 
   if (opts.onlyDriver && opts.drivers[opts.onlyDriver]) {
-    const chromeDriverProcess = await startDriver(
-      fsPaths[opts.onlyDriver].installPath,
-      [...opts.drivers[opts.onlyDriver].onlyDriverArgs, ...(!opts.drivers[opts.onlyDriver].onlyDriverArgs.some(item => item.includes('--port=')) && opts.onlyDriver !== 'firefox' ? [`--port=9515`] : [])]
-    );
+    const chromeDriverProcess = await startDriver(fsPaths[opts.onlyDriver].installPath, [
+      ...opts.drivers[opts.onlyDriver].onlyDriverArgs,
+      ...(!opts.drivers[opts.onlyDriver].onlyDriverArgs.some((item) => item.includes('--port=')) &&
+      opts.onlyDriver !== 'firefox'
+        ? [`--port=9515`]
+        : []),
+    ]);
 
     return chromeDriverProcess;
     // eslint-disable-next-line no-else-return

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.1",
         "execa": "^5.1.1",
-        "find-process": "^1.4.7",
+        "find-process": "1.4.7",
         "fkill": "^7.2.1",
         "got": "^11.8.6",
         "http-proxy-agent": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "cross-spawn": "^7.0.3",
     "debug": "^4.3.1",
     "execa": "^5.1.1",
-    "find-process": "^1.4.7",
+    "find-process": "1.4.7",
     "fkill": "^7.2.1",
     "got": "^11.8.6",
     "http-proxy-agent": "^7.0.2",


### PR DESCRIPTION
1. set find-process's version to exact 1.4.7 (cause version above supports only node v20)
2. forced port 9515 by default for chrome,edge drivers (issue https://www.autoitscript.com/forum/topic/212201-chromedriver-issues-august-2024/)
3. added 'exact match feature' https://github.com/webdriverio/selenium-standalone/issues/917